### PR TITLE
Spurce up CI file and switch to micromamba

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,21 +1,13 @@
 name: CI
 
 on:
-  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
-  # Existing codes likely still have "master" as the primary branch
-  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
-      - "master"
       - "main"
   pull_request:
     branches:
-      - "master"
       - "main"
   schedule:
-    # Nightly tests run on master by default:
-    #   Scheduled workflows run on the latest commit on the default or base branch.
-    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
     - cron: "0 0 * * *"
 
 jobs:
@@ -29,7 +21,7 @@ jobs:
         python-version: [3.8, 3.9, "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Additional info about the build
       shell: bash
@@ -40,16 +32,13 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v2
+    - name: Setup Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml
-
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
+        environment-name: test
+        extra-specs: |
+          python==${{ matrix.python-version }}
     
     - name: Install package
 
@@ -57,7 +46,7 @@ jobs:
       shell: bash -l {0}
       run: |
         python -m pip install . --no-deps
-        conda list
+        micromamba list
 
 
     - name: Run tests
@@ -69,6 +58,8 @@ jobs:
         pytest -v --cov=mtenn --cov-report=xml --color=yes mtenn/tests/
 
     - name: CodeCov
+      if: ${{ github.repository == 'choderalab/mtenn'
+                && github.event != 'schedule' }}
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml


### PR DESCRIPTION
* Switch to micromamba, much faster than conda
* Remove references to `master` branch which we don't need
* Remove extra comments
* Set codecov to no try and run on forks + schedule runs
* Update github checkout to newest version

