### PR TITLE
Update bias assignment in DGL GAT model

### DIFF
--- a/mtenn/conversion_utils/gat.py
+++ b/mtenn/conversion_utils/gat.py
@@ -31,22 +31,22 @@ class GAT(torch.nn.Module):
             num_heads = model.num_heads
             agg_modes = model.agg_modes
             # Parameters that can only be adcessed layer-wise
-            layer_params = [
-                (
-                    l.gat_conv.feat_drop.p,
-                    l.gat_conv.attn_drop.p,
-                    l.gat_conv.leaky_relu.negative_slope,
-                    bool(l.gat_conv.res_fc),
-                    l.gat_conv.activation,
-                    bool(l.gat_conv.bias),
+            layer_params = []
+            for l in model.gnn_layers:
+                gc = l.gat_conv
+                new_params = (
+                    gc.feat_drop.p,
+                    gc.attn_drop.p,
+                    gc.leaky_relu.negative_slope,
+                    bool(gc.res_fc),
+                    gc.activation,
+                    gc.res_fc.bias if gc.has_linear_res else gc.has_explicit_bias,
                 )
-                for l in model.gnn_layers
-            ]
+
             (
                 feat_drops,
                 attn_drops,
                 alphas,
-                residuals,
                 activations,
                 residuals,
                 biases,

--- a/mtenn/conversion_utils/gat.py
+++ b/mtenn/conversion_utils/gat.py
@@ -19,10 +19,11 @@ from ..model import (
 
 class GAT(torch.nn.Module):
     def __init__(self, *args, model=None, **kwargs):
+        super().__init__()
+
         ## If no model is passed, construct model based on passed args, otherwise copy
         ##  all parameters and weights over
         if model is None:
-            super().__init__()
             self.gnn = GAT_dgl(*args, **kwargs)
         else:
             # Parameters that are conveniently accessible from the top level
@@ -38,10 +39,13 @@ class GAT(torch.nn.Module):
                     gc.feat_drop.p,
                     gc.attn_drop.p,
                     gc.leaky_relu.negative_slope,
-                    bool(gc.res_fc),
                     gc.activation,
-                    gc.res_fc.bias if gc.has_linear_res else gc.has_explicit_bias,
+                    bool(gc.res_fc),
+                    (gc.res_fc.bias is not None)
+                    if gc.has_linear_res
+                    else gc.has_explicit_bias,
                 )
+                layer_params += [new_params]
 
             (
                 feat_drops,


### PR DESCRIPTION
DGL 1.1 changed how bias terms are assigned in the `GATConv` layer. Update Our `GAT` model to reflect these changes.