### PR TITLE
Update LigandOnlyModel return to match other Model classes.

### DIFF
--- a/mtenn/model.py
+++ b/mtenn/model.py
@@ -247,6 +247,6 @@ class LigandOnlyModel(Model):
         pred = self.get_representation(tmp_rep)
 
         if self.readout:
-            return self.readout(pred)
+            return self.readout(pred), [pred]
         else:
-            return pred
+            return pred, [pred]


### PR DESCRIPTION
Update the `LigandOnlyModel` forward pass to return the prediction and the prediction in a list to match the signature of the other `Model` classes.