### PR TITLE
Fix torchdata pins for dgl

### DIFF
--- a/devtools/conda-envs/mtenn.yaml
+++ b/devtools/conda-envs/mtenn.yaml
@@ -3,7 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - pytorch
-  - pytorch_geometric >=2.5.0
+  - torchdata <=0.9.0
+  - pytorch_geometric
   - pytorch_cluster
   - pytorch_scatter
   - pytorch_sparse

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -3,7 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - pytorch
-  - pytorch_geometric >=2.5.0
+  - torchdata <=0.9.0
+  - pytorch_geometric
   - pytorch_cluster
   - pytorch_scatter
   - pytorch_sparse


### PR DESCRIPTION
Some stuff was removed from the `torchdata` package that `dgl` depends on, so pin it for now pending removal of `dgl`.